### PR TITLE
Fix bump sensor detection

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -337,11 +337,16 @@ def _update_intersection_debounce(readings):
 
 def bumped():
     """Return True only if a bumper is pressed continuously for ~40 ms."""
-    if not (bump.left_is_pressed() or bump.right_is_pressed()):
-        return False
+    bump.read()
     if bump.left_is_pressed() or bump.right_is_pressed():
+        start = time.ticks_ms()
+        while time.ticks_diff(time.ticks_ms(), start) < 40:
+            bump.read()
+            if not (bump.left_is_pressed() or bump.right_is_pressed()):
+                return False
         flash_red_LEDS(1)
         return True
+    return False
 
 
 def move_forward_one_cell():


### PR DESCRIPTION
## Summary
- ensure bump sensors are read before checks
- require stable 40ms press to trigger bump

## Testing
- `python -m py_compile pololu-astar.py`


------
https://chatgpt.com/codex/tasks/task_e_689d5be746f883279aaf368e65e4d43a