### PR TITLE
Handle UART line stripping inside handler

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -243,6 +243,9 @@ def handle_uart_line(line):
     """
     global other_intent, other_intent_time_ms, first_clue_seen
 
+    # Trim whitespace or stray terminators and parse
+    line = line.strip()
+
     # Minimal parsing: "<sender>/<topic>:<payload>"
     try:
         left, payload = line.split("=", 1)
@@ -276,7 +279,7 @@ def handle_uart_line(line):
 def uart_rx_loop():
     """
     Background reader thread:
-      - Buffers bytes until newline
+      - Buffers bytes until '-' (our message terminator)
       - Calls handle_uart_line() per complete line
       - Respects the 'running' flag for clean exit
     """
@@ -287,8 +290,7 @@ def uart_rx_loop():
             if not b:
                 continue
             if b == b"-":
-                line = buf.decode(errors="ignore").strip()
-                msg = line[:-1]
+                line = buf.decode(errors="ignore")
                 if line:
                     handle_uart_line(line)
                 buf = b""


### PR DESCRIPTION
## Summary
- Pass complete decoded UART messages to `handle_uart_line` instead of truncating bytes in `uart_rx_loop`
- Strip whitespace/terminators within `handle_uart_line` before parsing
- Document that `uart_rx_loop` uses '-' as the message terminator

## Testing
- `python -m py_compile pololu-astar.py`


------
https://chatgpt.com/codex/tasks/task_e_689e2b7eea94832781194a287c92e89f