### PR TITLE
Rename reward_map references to prob_map

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -638,7 +638,7 @@ def pick_goal():
             i = idx(x, y)
             if grid[i] != 0:
                 continue
-            val = reward_map[i] * REWARD_FACTOR
+            val = prob_map[i] * REWARD_FACTOR
 
             if not first_clue_seen:
                 # Static nudge to keep targets in outer strips pre-clue
@@ -698,7 +698,7 @@ def a_star(start, goal):
                 new_cost += cfg.VISITED_STEP_PENALTY
 
             # Reward shaping (prefer high reward)
-            new_cost -= reward_map[i] * REWARD_FACTOR
+            new_cost -= prob_map[i] * REWARD_FACTOR
 
             # Pre-clue: penalize inward hops (serpentine)
             new_cost += centerward_step_cost(cx, nx)


### PR DESCRIPTION
## Summary
- Use `prob_map` consistently for reward values by removing leftover `reward_map` references.
- Ensure `update_prob_map` populates the same `prob_map` array used during goal selection and A* planning.

## Testing
- `python -m py_compile pololu-astar.py`
- ⚠️ `python pololu-astar.py` *(fails: No module named 'machine')*


------
https://chatgpt.com/codex/tasks/task_e_68b0edb83bd4832799a29ab2d63355ca