### PR TITLE
Collect garbage after calibration

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -611,6 +611,7 @@ def calibrate():
 
     motors_off()
     METRIC_START_TIME_MS = time.ticks_ms()
+    gc.collect()
     
 
 def at_intersection_and_white():


### PR DESCRIPTION
## Summary
- free heap after calibration by calling `gc.collect()` before the search loop resumes

## Testing
- `python -m py_compile pololu-astar.py`
- `python pololu-astar.py` *(fails: ModuleNotFoundError: No module named 'machine')*


------
https://chatgpt.com/codex/tasks/task_e_68b1e5fa87f0832781bf6732ac8d3bd6